### PR TITLE
Fix spelling mistake in comment

### DIFF
--- a/src/identity/forget.rs
+++ b/src/identity/forget.rs
@@ -162,7 +162,7 @@ mod tests {
         assert_eq!(balance(&service, &USER_A.to_string()).await, 10000);
         assert_eq!(balance(&service, &user_b.to_string()).await, 1000);
         assert_eq!(balance(&service, &user_c.to_string()).await, 1000);
-        // this is implementation of forget() but with overriden timestamp
+        // this is implementation of forget() but with overridden timestamp
         service
             .forget_with_timestamp(USER_A.to_string(), user_b.to_string(), ts - 86400 * 2)
             .await;


### PR DESCRIPTION
## Summary
- fix comment in forget test to say "overridden" instead of "overriden"

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_685eace830fc832894f9e7c188ecfef0