### PR TITLE
Add nonce reuse assertion in signature tests

### DIFF
--- a/src/verify/signature.rs
+++ b/src/verify/signature.rs
@@ -45,7 +45,7 @@ impl Signature {
 
 #[cfg(test)]
 mod tests {
-    use crate::verify::{nonce::InMemoryNonceManager, random_keypair};
+    use crate::verify::{error::Error, nonce::InMemoryNonceManager, random_keypair};
 
     use super::*;
 
@@ -128,6 +128,7 @@ mod tests {
             .expect("Should generate signature");
         assert!(signature.verify(message, &nonce_manager).is_ok());
         // second verification with the same nonce should fail
-        assert!(signature.verify(message, &nonce_manager).is_err());
+        let err = signature.verify(message, &nonce_manager).unwrap_err();
+        assert!(matches!(err, Error::NonceUsedError(_)));
     }
 }


### PR DESCRIPTION
## Summary
- capture the verification error for duplicate nonce
- assert returned error matches `Error::NonceUsedError(_)`
- fix import ordering in signature test module

## Testing
- `cargo test --locked`
- `cargo fmt --all -- --check`


------
https://chatgpt.com/codex/tasks/task_e_685eacf1eb648328a24a56d7024a8e2e