### PR TITLE
Add nonce error assertion to forget test

### DIFF
--- a/src/verify/forget.rs
+++ b/src/verify/forget.rs
@@ -82,6 +82,7 @@ mod tests {
             .expect("Should generate signature");
         assert!(forget_verify(&signature, user.clone(), &nonce_manager).is_ok());
         // duplicate verification with the same nonce should fail
-        assert!(forget_verify(&signature, user, &nonce_manager).is_err());
+        let err = forget_verify(&signature, user, &nonce_manager).unwrap_err();
+        assert!(matches!(err, Error::NonceUsedError(_)));
     }
 }


### PR DESCRIPTION
## Summary
- update `forget.rs` tests to capture `NonceUsedError`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685eb720f8a88328b1bd127fe4f9392a