### PR TITLE
Fix penalty test

### DIFF
--- a/src/identity/punish.rs
+++ b/src/identity/punish.rs
@@ -269,7 +269,7 @@ mod tests {
             PROOF_ID,
         );
         assert_eq!(balance(&service, &USER_A.to_string()).await, 50);
-        assert_eq!(balance(&service, &USER_A.to_string()).await, 50);
+        assert_eq!(penalty(&service, &USER_A.to_string()).await, 50);
     }
 
     #[async_std::test]


### PR DESCRIPTION
## Summary
- fix the penalty test by removing a duplicate balance assertion
- verify the user's penalty after applying punishment

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685eb70995d88328b1e77d88e0b31c0c