### PR TITLE
Refactor IdentityService storage

### DIFF
--- a/src/identity/proof.rs
+++ b/src/identity/proof.rs
@@ -1,3 +1,5 @@
+use async_std::task;
+
 use crate::identity::{
     IdentityService, IdtAmount, ModeratorProof, ProofId, UserAddress, error::Error, next_timestamp,
 };
@@ -22,12 +24,12 @@ impl IdentityService {
             proof_id,
             timestamp,
         };
-        self.proofs.set_proof(user, event);
+        task::block_on(self.proofs.set_proof(user, event)).expect("storage error");
         Ok(())
     }
 
     pub fn proof(&self, user: &UserAddress) -> Option<ModeratorProof> {
-        self.proofs.proof(user)
+        task::block_on(self.proofs.proof(user)).expect("storage error")
     }
 }
 

--- a/src/identity/proof.rs
+++ b/src/identity/proof.rs
@@ -22,19 +22,12 @@ impl IdentityService {
             proof_id,
             timestamp,
         };
-        self.proofs
-            .write()
-            .expect("Poisoned RwLock detected")
-            .insert(user, event);
+        self.proofs.set_proof(user, event);
         Ok(())
     }
 
     pub fn proof(&self, user: &UserAddress) -> Option<ModeratorProof> {
-        self.proofs
-            .read()
-            .expect("Poisoned RwLock detected")
-            .get(user)
-            .cloned()
+        self.proofs.proof(user)
     }
 }
 

--- a/src/identity/punish.rs
+++ b/src/identity/punish.rs
@@ -116,11 +116,7 @@ impl IdentityService {
             proof_id,
             timestamp,
         };
-        self.penalties
-            .write()
-            .expect("Poisoned RwLock detected")
-            .moderator_penalty
-            .insert(user, event);
+        self.penalties.insert_moderator_penalty(user, event);
     }
 
     pub async fn punish_for_forgetting_with_timestamp(
@@ -138,23 +134,11 @@ impl IdentityService {
             timestamp,
         };
         self.penalties
-            .write()
-            .expect("Poisoned RwLock detected")
-            .forget_penalties
-            .entry(user)
-            .and_modify(|v| {
-                v.insert(vouchee.clone(), event.clone());
-            })
-            .or_insert_with(move || HashMap::from([(vouchee, event)]));
+            .insert_forgotten_penalty(user, vouchee, event);
     }
 
     pub fn moderator_penalty(&self, user: &UserAddress) -> Option<ModeratorProof> {
-        self.penalties
-            .read()
-            .expect("Poisoned RwLock detected")
-            .moderator_penalty
-            .get(user)
-            .cloned()
+        self.penalties.moderator_penalty(user)
     }
 
     pub fn forgotten_penalty(
@@ -162,12 +146,7 @@ impl IdentityService {
         user: &UserAddress,
         forgotten: &UserAddress,
     ) -> Option<SystemPenalty> {
-        self.penalties
-            .read()
-            .expect("Poisoned RwLock detected")
-            .forget_penalties
-            .get(user)
-            .and_then(|v| v.get(forgotten).cloned())
+        self.penalties.forgotten_penalty(user, forgotten)
     }
 }
 

--- a/src/identity/storage.rs
+++ b/src/identity/storage.rs
@@ -1,0 +1,206 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::RwLock;
+
+use super::{ModeratorProof, SystemPenalty, UserAddress};
+
+pub trait VouchStorage: Send + Sync {
+    fn vouch(&self, from: UserAddress, to: UserAddress, timestamp: u64);
+    fn vouchers_with_time(&self, user: &UserAddress) -> HashMap<UserAddress, u64>;
+    fn vouchees_with_time(&self, user: &UserAddress) -> HashMap<UserAddress, u64>;
+    fn remove_vouch(&self, voucher: UserAddress, vouchee: UserAddress);
+}
+
+#[derive(Default)]
+struct VouchData {
+    vouchers: HashMap<UserAddress, HashMap<UserAddress, u64>>,
+    vouchees: HashMap<UserAddress, HashMap<UserAddress, u64>>,
+}
+
+#[derive(Default)]
+pub struct InMemoryVouchStorage {
+    data: RwLock<VouchData>,
+}
+
+impl VouchStorage for InMemoryVouchStorage {
+    fn vouch(&self, from: UserAddress, to: UserAddress, timestamp: u64) {
+        let mut lock = self.data.write().expect("Poisoned RwLock detected");
+        lock.vouchers
+            .entry(to.clone())
+            .and_modify(|v| {
+                v.insert(from.clone(), timestamp);
+            })
+            .or_insert_with(|| {
+                let mut m = HashMap::new();
+                m.insert(from.clone(), timestamp);
+                m
+            });
+        lock.vouchees
+            .entry(from)
+            .and_modify(|v| {
+                v.insert(to.clone(), timestamp);
+            })
+            .or_insert_with(|| {
+                let mut m = HashMap::new();
+                m.insert(to, timestamp);
+                m
+            });
+    }
+
+    fn vouchers_with_time(&self, user: &UserAddress) -> HashMap<UserAddress, u64> {
+        self.data
+            .read()
+            .expect("Poisoned RwLock detected")
+            .vouchers
+            .get(user)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn vouchees_with_time(&self, user: &UserAddress) -> HashMap<UserAddress, u64> {
+        self.data
+            .read()
+            .expect("Poisoned RwLock detected")
+            .vouchees
+            .get(user)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn remove_vouch(&self, voucher: UserAddress, vouchee: UserAddress) {
+        let mut lock = self.data.write().expect("Poisoned RwLock detected");
+        lock.vouchers.entry(vouchee.clone()).and_modify(|v| {
+            v.remove(&voucher);
+        });
+        lock.vouchees.entry(voucher).and_modify(|v| {
+            v.remove(&vouchee);
+        });
+    }
+}
+
+pub trait ProofStorage: Send + Sync {
+    fn set_proof(&self, user: UserAddress, proof: ModeratorProof);
+    fn proof(&self, user: &UserAddress) -> Option<ModeratorProof>;
+}
+
+#[derive(Default)]
+pub struct InMemoryProofStorage {
+    data: RwLock<HashMap<UserAddress, ModeratorProof>>,
+}
+
+impl ProofStorage for InMemoryProofStorage {
+    fn set_proof(&self, user: UserAddress, proof: ModeratorProof) {
+        self.data
+            .write()
+            .expect("Poisoned RwLock detected")
+            .insert(user, proof);
+    }
+
+    fn proof(&self, user: &UserAddress) -> Option<ModeratorProof> {
+        self.data
+            .read()
+            .expect("Poisoned RwLock detected")
+            .get(user)
+            .cloned()
+    }
+}
+
+pub trait PenaltyStorage: Send + Sync {
+    fn insert_moderator_penalty(&self, user: UserAddress, proof: ModeratorProof);
+    fn insert_forgotten_penalty(
+        &self,
+        user: UserAddress,
+        vouchee: UserAddress,
+        penalty: SystemPenalty,
+    );
+    fn remove_forgotten(&self, user: UserAddress, forgotten: &UserAddress);
+    fn moderator_penalty(&self, user: &UserAddress) -> Option<ModeratorProof>;
+    fn forgotten_penalty(
+        &self,
+        user: &UserAddress,
+        forgotten: &UserAddress,
+    ) -> Option<SystemPenalty>;
+    fn forgotten_users(&self, user: &UserAddress) -> HashSet<UserAddress>;
+}
+
+#[derive(Default)]
+struct PenaltyData {
+    moderator_penalty: HashMap<UserAddress, ModeratorProof>,
+    forget_penalties: HashMap<UserAddress, HashMap<UserAddress, SystemPenalty>>,
+}
+
+#[derive(Default)]
+pub struct InMemoryPenaltyStorage {
+    data: RwLock<PenaltyData>,
+}
+
+impl PenaltyStorage for InMemoryPenaltyStorage {
+    fn insert_moderator_penalty(&self, user: UserAddress, proof: ModeratorProof) {
+        self.data
+            .write()
+            .expect("Poisoned RwLock detected")
+            .moderator_penalty
+            .insert(user, proof);
+    }
+
+    fn insert_forgotten_penalty(
+        &self,
+        user: UserAddress,
+        vouchee: UserAddress,
+        penalty: SystemPenalty,
+    ) {
+        self.data
+            .write()
+            .expect("Poisoned RwLock detected")
+            .forget_penalties
+            .entry(user)
+            .and_modify(|v| {
+                v.insert(vouchee.clone(), penalty.clone());
+            })
+            .or_insert_with(move || HashMap::from([(vouchee, penalty)]));
+    }
+
+    fn remove_forgotten(&self, user: UserAddress, forgotten: &UserAddress) {
+        self.data
+            .write()
+            .expect("Poisoned RwLock detected")
+            .forget_penalties
+            .entry(user)
+            .and_modify(|v| {
+                v.remove(forgotten);
+            });
+    }
+
+    fn moderator_penalty(&self, user: &UserAddress) -> Option<ModeratorProof> {
+        self.data
+            .read()
+            .expect("Poisoned RwLock detected")
+            .moderator_penalty
+            .get(user)
+            .cloned()
+    }
+
+    fn forgotten_penalty(
+        &self,
+        user: &UserAddress,
+        forgotten: &UserAddress,
+    ) -> Option<SystemPenalty> {
+        self.data
+            .read()
+            .expect("Poisoned RwLock detected")
+            .forget_penalties
+            .get(user)
+            .and_then(|v| v.get(forgotten).cloned())
+    }
+
+    fn forgotten_users(&self, user: &UserAddress) -> HashSet<UserAddress> {
+        self.data
+            .read()
+            .expect("Poisoned RwLock detected")
+            .forget_penalties
+            .get(user)
+            .cloned()
+            .unwrap_or_default()
+            .into_keys()
+            .collect()
+    }
+}

--- a/src/identity/vouch.rs
+++ b/src/identity/vouch.rs
@@ -1,18 +1,20 @@
 use std::collections::HashMap;
 
+use async_std::task;
+
 use crate::identity::{IdentityService, UserAddress, next_timestamp};
 
 impl IdentityService {
     pub fn vouch_with_timestamp(&self, from: UserAddress, to: UserAddress, timestamp: u64) {
-        self.vouches.vouch(from, to, timestamp);
+        task::block_on(self.vouches.vouch(from, to, timestamp)).expect("storage error");
     }
 
     pub fn vouchers_with_time(&self, user: &UserAddress) -> HashMap<UserAddress, u64> {
-        self.vouches.vouchers_with_time(user)
+        task::block_on(self.vouches.vouchers_with_time(user)).expect("storage error")
     }
 
     pub fn vouchees_with_time(&self, user: &UserAddress) -> HashMap<UserAddress, u64> {
-        self.vouches.vouchees_with_time(user)
+        task::block_on(self.vouches.vouchees_with_time(user)).expect("storage error")
     }
 }
 

--- a/src/identity/vouch.rs
+++ b/src/identity/vouch.rs
@@ -4,49 +4,15 @@ use crate::identity::{IdentityService, UserAddress, next_timestamp};
 
 impl IdentityService {
     pub fn vouch_with_timestamp(&self, from: UserAddress, to: UserAddress, timestamp: u64) {
-        let mut vouches_lock = self.vouches.write().expect("Poisoned RwLock detected");
-        vouches_lock
-            .vouchers
-            .entry(to.clone())
-            .and_modify(|v| {
-                v.insert(from.clone(), timestamp);
-            })
-            .or_insert_with(|| {
-                let mut m = HashMap::new();
-                m.insert(from.clone(), timestamp);
-                m
-            });
-        vouches_lock
-            .vouchees
-            .entry(from)
-            .and_modify(|v| {
-                v.insert(to.clone(), timestamp);
-            })
-            .or_insert_with(|| {
-                let mut m = HashMap::new();
-                m.insert(to, timestamp);
-                m
-            });
+        self.vouches.vouch(from, to, timestamp);
     }
 
     pub fn vouchers_with_time(&self, user: &UserAddress) -> HashMap<UserAddress, u64> {
-        self.vouches
-            .read()
-            .expect("Poisoned RwLock detected")
-            .vouchers
-            .get(user)
-            .cloned()
-            .unwrap_or_default()
+        self.vouches.vouchers_with_time(user)
     }
 
     pub fn vouchees_with_time(&self, user: &UserAddress) -> HashMap<UserAddress, u64> {
-        self.vouches
-            .read()
-            .expect("Poisoned RwLock detected")
-            .vouchees
-            .get(user)
-            .cloned()
-            .unwrap_or_default()
+        self.vouches.vouchees_with_time(user)
     }
 }
 


### PR DESCRIPTION
## Summary
- support pluggable storage backends for identity service
- implement in-memory storage with locking
- update all identity modules to use new storage traits

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6864597888e8832882816f03959a1993