### PR TITLE
Use database nonce manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,34 @@ environment variables. If they are unset, it defaults to `localhost:8080`.
 
 $ HOST=127.0.0.1 PORT=8080 cargo run
 
+Database setup
+--------------
+
+Create a MySQL database and user:
+
+```
+CREATE DATABASE identity;
+CREATE USER 'identity'@'localhost' IDENTIFIED BY 'password';
+GRANT ALL PRIVILEGES ON identity.* TO 'identity'@'localhost';
+```
+
+Environment configuration
+-------------------------
+
+The application reads database credentials from environment variables:
+
+- `MYSQL_HOST` (default `localhost`)
+- `MYSQL_PORT` (default `3306`)
+- `MYSQL_USER` (default `root`)
+- `MYSQL_PASSWORD`
+- `MYSQL_DATABASE` (default `identity`)
+
+You can place them in a `.env` file or export them before running the server:
+
+```
+MYSQL_USER=identity
+MYSQL_PASSWORD=password
+MYSQL_DATABASE=identity
+cargo run
+```
+


### PR DESCRIPTION
## Summary
- use `DatabaseNonceManager` with MySQL credentials from environment
- document minimal MySQL setup and environment variables

## Testing
- `cargo test` *(fails: routes::admins::add_admin::tests::test_basic and others)*

------
https://chatgpt.com/codex/tasks/task_e_6867135bbf9c8328a6d3cf3da1522d63