### PR TITLE
Add database storage implementations

### DIFF
--- a/src/admins/db.rs
+++ b/src/admins/db.rs
@@ -1,0 +1,114 @@
+use async_trait::async_trait;
+use sqlx::AnyPool;
+use sqlx::any::AnyPoolOptions;
+
+use crate::admins::{AdminStorage, error::Error};
+use crate::identity::UserAddress;
+
+pub struct DatabaseAdminStorage {
+    pool: AnyPool,
+}
+
+impl DatabaseAdminStorage {
+    pub async fn new(
+        url: &str,
+        admins: impl IntoIterator<Item = UserAddress>,
+        moderators: impl IntoIterator<Item = UserAddress>,
+    ) -> Result<Self, Error> {
+        sqlx::any::install_default_drivers();
+        let pool = AnyPoolOptions::new()
+            .max_connections(1)
+            .connect(url)
+            .await?;
+        sqlx::query("CREATE TABLE IF NOT EXISTS admins (user TEXT PRIMARY KEY)")
+            .execute(&pool)
+            .await?;
+        sqlx::query("CREATE TABLE IF NOT EXISTS moderators (user TEXT PRIMARY KEY)")
+            .execute(&pool)
+            .await?;
+        for admin in admins {
+            sqlx::query("INSERT OR IGNORE INTO admins (user) VALUES (?)")
+                .bind(admin)
+                .execute(&pool)
+                .await?;
+        }
+        for moderator in moderators {
+            sqlx::query("INSERT OR IGNORE INTO moderators (user) VALUES (?)")
+                .bind(moderator)
+                .execute(&pool)
+                .await?;
+        }
+        Ok(Self { pool })
+    }
+}
+
+#[async_trait]
+impl AdminStorage for DatabaseAdminStorage {
+    async fn is_admin(&self, user: &UserAddress) -> Result<(), Error> {
+        let row = sqlx::query("SELECT user FROM admins WHERE user = ?")
+            .bind(user)
+            .fetch_optional(&self.pool)
+            .await?;
+        if row.is_some() {
+            Ok(())
+        } else {
+            Err(Error::NoAdminPrivilege)
+        }
+    }
+
+    async fn is_moderator(&self, user: &UserAddress) -> Result<(), Error> {
+        let row = sqlx::query("SELECT user FROM moderators WHERE user = ?")
+            .bind(user)
+            .fetch_optional(&self.pool)
+            .await?;
+        if row.is_some() {
+            Ok(())
+        } else {
+            Err(Error::NoAdminPrivilege)
+        }
+    }
+
+    async fn add_admin(&self, caller: &UserAddress, new_admin: UserAddress) -> Result<(), Error> {
+        self.is_admin(caller).await?;
+        sqlx::query("INSERT OR IGNORE INTO admins (user) VALUES (?)")
+            .bind(new_admin)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn remove_admin(&self, caller: &UserAddress, admin: UserAddress) -> Result<(), Error> {
+        self.is_admin(caller).await?;
+        sqlx::query("DELETE FROM admins WHERE user = ?")
+            .bind(admin)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn add_moderator(
+        &self,
+        caller: &UserAddress,
+        moderator: UserAddress,
+    ) -> Result<(), Error> {
+        self.is_admin(caller).await?;
+        sqlx::query("INSERT OR IGNORE INTO moderators (user) VALUES (?)")
+            .bind(moderator)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn remove_moderator(
+        &self,
+        caller: &UserAddress,
+        moderator: UserAddress,
+    ) -> Result<(), Error> {
+        self.is_admin(caller).await?;
+        sqlx::query("DELETE FROM moderators WHERE user = ?")
+            .bind(moderator)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+}

--- a/src/admins/error.rs
+++ b/src/admins/error.rs
@@ -2,4 +2,6 @@
 pub enum Error {
     #[error("Caller does not have admin privileges")]
     NoAdminPrivilege,
+    #[error("Database error: {0}")]
+    DatabaseError(#[from] sqlx::Error),
 }

--- a/src/admins/mod.rs
+++ b/src/admins/mod.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use crate::{admins::error::Error, identity::UserAddress};
 use std::collections::HashSet;
 
+pub mod db;
 pub mod error;
 
 #[async_trait]

--- a/src/identity/error.rs
+++ b/src/identity/error.rs
@@ -2,4 +2,6 @@
 pub enum Error {
     #[error("Max balance from proof exceeded")]
     MaxBalanceExceeded,
+    #[error("Database error: {0}")]
+    DatabaseError(#[from] sqlx::Error),
 }

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -4,6 +4,7 @@ use crate::identity::storage::{
     InMemoryPenaltyStorage, InMemoryProofStorage, InMemoryVouchStorage, PenaltyStorage,
     ProofStorage, VouchStorage,
 };
+// Database storage implementations are available in `storage_db` module
 
 mod decay;
 pub mod error;
@@ -13,6 +14,7 @@ pub mod idt;
 pub mod proof;
 pub mod punish;
 pub mod storage;
+pub mod storage_db;
 mod tree_walk;
 pub mod vouch;
 

--- a/src/identity/storage_db.rs
+++ b/src/identity/storage_db.rs
@@ -1,0 +1,343 @@
+use async_trait::async_trait;
+use sqlx::any::AnyPoolOptions;
+use sqlx::{Acquire, AnyPool, Row};
+
+use crate::identity::error::Error;
+use crate::identity::storage::{PenaltyStorage, ProofStorage, VouchStorage};
+use crate::identity::{IdtAmount, ModeratorProof, SystemPenalty, UserAddress};
+
+pub struct DatabaseVouchStorage {
+    pool: AnyPool,
+}
+
+impl DatabaseVouchStorage {
+    pub async fn new(url: &str) -> Result<Self, Error> {
+        sqlx::any::install_default_drivers();
+        let pool = AnyPoolOptions::new()
+            .max_connections(1)
+            .connect(url)
+            .await?;
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS vouches (voucher TEXT NOT NULL, vouchee TEXT NOT NULL, timestamp INTEGER NOT NULL, PRIMARY KEY(voucher, vouchee))"
+        )
+        .execute(&pool)
+        .await?;
+        Ok(Self { pool })
+    }
+}
+
+#[async_trait]
+impl VouchStorage for DatabaseVouchStorage {
+    async fn vouch(&self, from: UserAddress, to: UserAddress, timestamp: u64) -> Result<(), Error> {
+        let mut tx = self.pool.begin().await?;
+        let row = sqlx::query("SELECT timestamp FROM vouches WHERE voucher = ? AND vouchee = ?")
+            .bind(&from)
+            .bind(&to)
+            .fetch_optional(tx.acquire().await?)
+            .await?;
+        if row.is_some() {
+            sqlx::query("UPDATE vouches SET timestamp = ? WHERE voucher = ? AND vouchee = ?")
+                .bind(timestamp as i64)
+                .bind(&from)
+                .bind(&to)
+                .execute(tx.acquire().await?)
+                .await?;
+        } else {
+            sqlx::query("INSERT INTO vouches (voucher, vouchee, timestamp) VALUES (?, ?, ?)")
+                .bind(&from)
+                .bind(&to)
+                .bind(timestamp as i64)
+                .execute(tx.acquire().await?)
+                .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn vouchers_with_time(
+        &self,
+        user: &UserAddress,
+    ) -> Result<std::collections::HashMap<UserAddress, u64>, Error> {
+        let rows = sqlx::query("SELECT voucher, timestamp FROM vouches WHERE vouchee = ?")
+            .bind(user)
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| (r.get::<String, _>(0), r.get::<i64, _>(1) as u64))
+            .collect())
+    }
+
+    async fn vouchees_with_time(
+        &self,
+        user: &UserAddress,
+    ) -> Result<std::collections::HashMap<UserAddress, u64>, Error> {
+        let rows = sqlx::query("SELECT vouchee, timestamp FROM vouches WHERE voucher = ?")
+            .bind(user)
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| (r.get::<String, _>(0), r.get::<i64, _>(1) as u64))
+            .collect())
+    }
+
+    async fn remove_vouch(&self, voucher: UserAddress, vouchee: UserAddress) -> Result<(), Error> {
+        sqlx::query("DELETE FROM vouches WHERE voucher = ? AND vouchee = ?")
+            .bind(voucher)
+            .bind(vouchee)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+}
+
+pub struct DatabaseProofStorage {
+    pool: AnyPool,
+}
+
+impl DatabaseProofStorage {
+    pub async fn new(url: &str) -> Result<Self, Error> {
+        sqlx::any::install_default_drivers();
+        let pool = AnyPoolOptions::new()
+            .max_connections(1)
+            .connect(url)
+            .await?;
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS proofs (user TEXT PRIMARY KEY, moderator TEXT NOT NULL, amount INTEGER NOT NULL, proof_id INTEGER NOT NULL, timestamp INTEGER NOT NULL)"
+        )
+        .execute(&pool)
+        .await?;
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS genesis (user TEXT PRIMARY KEY, balance INTEGER NOT NULL)",
+        )
+        .execute(&pool)
+        .await?;
+        Ok(Self { pool })
+    }
+}
+
+#[async_trait]
+impl ProofStorage for DatabaseProofStorage {
+    async fn set_genesis(
+        &self,
+        users: std::collections::HashMap<UserAddress, IdtAmount>,
+    ) -> Result<(), Error> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("DELETE FROM genesis")
+            .execute(tx.acquire().await?)
+            .await?;
+        for (user, bal) in users {
+            sqlx::query("INSERT INTO genesis (user, balance) VALUES (?, ?)")
+                .bind(user)
+                .bind(bal as i64)
+                .execute(tx.acquire().await?)
+                .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn genesis_balance(&self, user: &UserAddress) -> Result<Option<IdtAmount>, Error> {
+        let row = sqlx::query("SELECT balance FROM genesis WHERE user = ?")
+            .bind(user)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row.map(|r| r.get::<i64, _>(0) as u128))
+    }
+
+    async fn set_proof(&self, user: UserAddress, proof: ModeratorProof) -> Result<(), Error> {
+        let mut tx = self.pool.begin().await?;
+        let row = sqlx::query("SELECT user FROM proofs WHERE user = ?")
+            .bind(&user)
+            .fetch_optional(tx.acquire().await?)
+            .await?;
+        if row.is_some() {
+            sqlx::query("UPDATE proofs SET moderator = ?, amount = ?, proof_id = ?, timestamp = ? WHERE user = ?")
+                .bind(&proof.moderator)
+                .bind(proof.amount as i64)
+                .bind(proof.proof_id as i64)
+                .bind(proof.timestamp as i64)
+                .bind(&user)
+                .execute(tx.acquire().await?)
+                .await?;
+        } else {
+            sqlx::query("INSERT INTO proofs (user, moderator, amount, proof_id, timestamp) VALUES (?, ?, ?, ?, ?)")
+                .bind(&user)
+                .bind(&proof.moderator)
+                .bind(proof.amount as i64)
+                .bind(proof.proof_id as i64)
+                .bind(proof.timestamp as i64)
+                .execute(tx.acquire().await?)
+                .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn proof(&self, user: &UserAddress) -> Result<Option<ModeratorProof>, Error> {
+        let row =
+            sqlx::query("SELECT moderator, amount, proof_id, timestamp FROM proofs WHERE user = ?")
+                .bind(user)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|r| ModeratorProof {
+            moderator: r.get::<String, _>(0),
+            amount: r.get::<i64, _>(1) as u128,
+            proof_id: r.get::<i64, _>(2) as u128,
+            timestamp: r.get::<i64, _>(3) as u64,
+        }))
+    }
+}
+
+pub struct DatabasePenaltyStorage {
+    pool: AnyPool,
+}
+
+impl DatabasePenaltyStorage {
+    pub async fn new(url: &str) -> Result<Self, Error> {
+        sqlx::any::install_default_drivers();
+        let pool = AnyPoolOptions::new()
+            .max_connections(1)
+            .connect(url)
+            .await?;
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS moderator_penalties (user TEXT PRIMARY KEY, moderator TEXT NOT NULL, amount INTEGER NOT NULL, proof_id INTEGER NOT NULL, timestamp INTEGER NOT NULL)"
+        )
+        .execute(&pool)
+        .await?;
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS forget_penalties (user TEXT NOT NULL, forgotten TEXT NOT NULL, amount INTEGER NOT NULL, timestamp INTEGER NOT NULL, PRIMARY KEY(user, forgotten))"
+        )
+        .execute(&pool)
+        .await?;
+        Ok(Self { pool })
+    }
+}
+
+#[async_trait]
+impl PenaltyStorage for DatabasePenaltyStorage {
+    async fn insert_moderator_penalty(
+        &self,
+        user: UserAddress,
+        proof: ModeratorProof,
+    ) -> Result<(), Error> {
+        let mut tx = self.pool.begin().await?;
+        let row = sqlx::query("SELECT user FROM moderator_penalties WHERE user = ?")
+            .bind(&user)
+            .fetch_optional(tx.acquire().await?)
+            .await?;
+        if row.is_some() {
+            sqlx::query("UPDATE moderator_penalties SET moderator = ?, amount = ?, proof_id = ?, timestamp = ? WHERE user = ?")
+                .bind(&proof.moderator)
+                .bind(proof.amount as i64)
+                .bind(proof.proof_id as i64)
+                .bind(proof.timestamp as i64)
+                .bind(&user)
+                .execute(tx.acquire().await?)
+                .await?;
+        } else {
+            sqlx::query("INSERT INTO moderator_penalties (user, moderator, amount, proof_id, timestamp) VALUES (?, ?, ?, ?, ?)")
+                .bind(&user)
+                .bind(&proof.moderator)
+                .bind(proof.amount as i64)
+                .bind(proof.proof_id as i64)
+                .bind(proof.timestamp as i64)
+                .execute(tx.acquire().await?)
+                .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn insert_forgotten_penalty(
+        &self,
+        user: UserAddress,
+        vouchee: UserAddress,
+        penalty: SystemPenalty,
+    ) -> Result<(), Error> {
+        let mut tx = self.pool.begin().await?;
+        let row =
+            sqlx::query("SELECT amount FROM forget_penalties WHERE user = ? AND forgotten = ?")
+                .bind(&user)
+                .bind(&vouchee)
+                .fetch_optional(tx.acquire().await?)
+                .await?;
+        if row.is_some() {
+            sqlx::query("UPDATE forget_penalties SET amount = ?, timestamp = ? WHERE user = ? AND forgotten = ?")
+                .bind(penalty.amount as i64)
+                .bind(penalty.timestamp as i64)
+                .bind(&user)
+                .bind(&vouchee)
+                .execute(tx.acquire().await?)
+                .await?;
+        } else {
+            sqlx::query("INSERT INTO forget_penalties (user, forgotten, amount, timestamp) VALUES (?, ?, ?, ?)")
+                .bind(&user)
+                .bind(&vouchee)
+                .bind(penalty.amount as i64)
+                .bind(penalty.timestamp as i64)
+                .execute(tx.acquire().await?)
+                .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn remove_forgotten(
+        &self,
+        user: UserAddress,
+        forgotten: &UserAddress,
+    ) -> Result<(), Error> {
+        sqlx::query("DELETE FROM forget_penalties WHERE user = ? AND forgotten = ?")
+            .bind(&user)
+            .bind(forgotten)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn moderator_penalty(&self, user: &UserAddress) -> Result<Option<ModeratorProof>, Error> {
+        let row = sqlx::query(
+            "SELECT moderator, amount, proof_id, timestamp FROM moderator_penalties WHERE user = ?",
+        )
+        .bind(user)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|r| ModeratorProof {
+            moderator: r.get::<String, _>(0),
+            amount: r.get::<i64, _>(1) as u128,
+            proof_id: r.get::<i64, _>(2) as u128,
+            timestamp: r.get::<i64, _>(3) as u64,
+        }))
+    }
+
+    async fn forgotten_penalty(
+        &self,
+        user: &UserAddress,
+        forgotten: &UserAddress,
+    ) -> Result<Option<SystemPenalty>, Error> {
+        let row = sqlx::query(
+            "SELECT amount, timestamp FROM forget_penalties WHERE user = ? AND forgotten = ?",
+        )
+        .bind(user)
+        .bind(forgotten)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|r| SystemPenalty {
+            amount: r.get::<i64, _>(0) as u128,
+            timestamp: r.get::<i64, _>(1) as u64,
+        }))
+    }
+
+    async fn forgotten_users(
+        &self,
+        user: &UserAddress,
+    ) -> Result<std::collections::HashSet<UserAddress>, Error> {
+        let rows = sqlx::query("SELECT forgotten FROM forget_penalties WHERE user = ?")
+            .bind(user)
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows.into_iter().map(|r| r.get::<String, _>(0)).collect())
+    }
+}

--- a/src/routes/proof.rs
+++ b/src/routes/proof.rs
@@ -79,6 +79,7 @@ pub async fn route(mut req: Request<State>) -> tide::Result {
                     .content_type(mime::JSON)
                     .build());
             }
+            _ => return Err(e.into()),
         }
     }
     let user_balance = balance(&req.state().identity_service, &user).await?;


### PR DESCRIPTION
## Summary
- implement `DatabaseAdminStorage` using SQLx
- support database errors in admin and identity error enums
- implement SQLx backed vouch, proof, and penalty storage
- handle `DatabaseError` in proof route
- document db backends in `identity` module

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68684dc7f4dc83289b138275a0e6498d