### PR TITLE
Add in-memory storage tests

### DIFF
--- a/src/admins/mod.rs
+++ b/src/admins/mod.rs
@@ -139,11 +139,17 @@ mod tests {
         );
         assert!(storage.check_moderator(&moderator).await.is_ok());
 
-        // non-admin can't add moderator
+        // non-admin can't add or remove moderators
         let another_user = "another".to_string();
         assert!(
             storage
                 .add_moderator(&another_user, "new_mod".to_string())
+                .await
+                .is_err()
+        );
+        assert!(
+            storage
+                .remove_moderator(&another_user, moderator.clone())
                 .await
                 .is_err()
         );
@@ -170,11 +176,17 @@ mod tests {
         assert!(storage.add_admin(&admin1, admin2.clone()).await.is_ok());
         assert!(storage.check_admin(&admin2).await.is_ok());
 
-        // only admins can add admins
+        // only admins can add or remove admins
         let non_admin = "non_admin".to_string();
         assert!(
             storage
                 .add_admin(&non_admin, "new_admin".to_string())
+                .await
+                .is_err()
+        );
+        assert!(
+            storage
+                .remove_admin(&non_admin, admin2.clone())
                 .await
                 .is_err()
         );

--- a/src/identity/proof/db.rs
+++ b/src/identity/proof/db.rs
@@ -157,7 +157,6 @@ mod tests {
         assert_eq!(res.proof_id, proof2.proof_id);
         assert_eq!(res.timestamp, proof2.timestamp);
 
-        // proof for non-existing user
         assert!(storage.proof(&"none".to_string()).await.unwrap().is_none());
     }
 }

--- a/src/identity/proof/db.rs
+++ b/src/identity/proof/db.rs
@@ -108,7 +108,7 @@ mod tests {
     use super::*;
 
     #[async_std::test]
-    async fn test_database_proof_storage() {
+    async fn test_basic() {
         let storage = DatabaseProofStorage::new("sqlite::memory:").await.unwrap();
         let user = "user".to_string();
         let moderator = "moderator".to_string();

--- a/src/identity/proof/storage.rs
+++ b/src/identity/proof/storage.rs
@@ -50,7 +50,7 @@ mod tests {
     use std::collections::HashMap;
 
     #[async_std::test]
-    async fn test_inmemory_proof_storage() {
+    async fn test_basic() {
         let storage = InMemoryProofStorage::default();
         let user = "user".to_string();
         let moderator = "moderator".to_string();

--- a/src/identity/proof/storage.rs
+++ b/src/identity/proof/storage.rs
@@ -43,3 +43,62 @@ impl ProofStorage for InMemoryProofStorage {
         Ok(self.data.read().await.get(user).cloned())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[async_std::test]
+    async fn test_inmemory_proof_storage() {
+        let storage = InMemoryProofStorage::default();
+        let user = "user".to_string();
+        let moderator = "moderator".to_string();
+
+        let mut genesis = HashMap::<UserAddress, IdtAmount>::new();
+        genesis.insert(user.clone(), 100);
+        storage.set_genesis(genesis).await.unwrap();
+        assert_eq!(storage.genesis_balance(&user).await.unwrap().unwrap(), 100);
+        assert!(
+            storage
+                .genesis_balance(&"none".to_string())
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        let proof1 = ModeratorProof {
+            moderator: moderator.clone(),
+            amount: 10,
+            proof_id: 1,
+            timestamp: 1,
+        };
+        storage
+            .set_proof(user.clone(), proof1.clone())
+            .await
+            .unwrap();
+        let res = storage.proof(&user).await.unwrap().unwrap();
+        assert_eq!(res.moderator, proof1.moderator);
+        assert_eq!(res.amount, proof1.amount);
+        assert_eq!(res.proof_id, proof1.proof_id);
+        assert_eq!(res.timestamp, proof1.timestamp);
+
+        let proof2 = ModeratorProof {
+            moderator: "mod2".to_string(),
+            amount: 20,
+            proof_id: 2,
+            timestamp: 2,
+        };
+        storage
+            .set_proof(user.clone(), proof2.clone())
+            .await
+            .unwrap();
+        let res = storage.proof(&user).await.unwrap().unwrap();
+        assert_eq!(res.moderator, proof2.moderator);
+        assert_eq!(res.amount, proof2.amount);
+        assert_eq!(res.proof_id, proof2.proof_id);
+        assert_eq!(res.timestamp, proof2.timestamp);
+
+        assert!(storage.proof(&"none".to_string()).await.unwrap().is_none());
+    }
+}

--- a/src/identity/punish/db.rs
+++ b/src/identity/punish/db.rs
@@ -265,5 +265,12 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+        assert!(
+            !storage
+                .forgotten_users(&user)
+                .await
+                .unwrap()
+                .contains(&vouchee)
+        );
     }
 }

--- a/src/identity/punish/db.rs
+++ b/src/identity/punish/db.rs
@@ -206,7 +206,6 @@ mod tests {
         assert_eq!(res.proof_id, proof2.proof_id);
         assert_eq!(res.timestamp, proof2.timestamp);
 
-        // penalty for non-existing user
         assert!(
             storage
                 .moderator_penalty(&"none".to_string())

--- a/src/identity/punish/db.rs
+++ b/src/identity/punish/db.rs
@@ -167,7 +167,7 @@ mod tests {
     use super::*;
 
     #[async_std::test]
-    async fn test_database_penalty_storage() {
+    async fn test_basic() {
         let storage = DatabasePenaltyStorage::new("sqlite::memory:")
             .await
             .unwrap();

--- a/src/identity/punish/storage.rs
+++ b/src/identity/punish/storage.rs
@@ -216,5 +216,12 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+        assert!(
+            !storage
+                .forgotten_users(&user)
+                .await
+                .unwrap()
+                .contains(&vouchee)
+        );
     }
 }

--- a/src/identity/punish/storage.rs
+++ b/src/identity/punish/storage.rs
@@ -121,7 +121,7 @@ mod tests {
     use super::*;
 
     #[async_std::test]
-    async fn test_inmemory_penalty_storage() {
+    async fn test_basic() {
         let storage = InMemoryPenaltyStorage::default();
         let user = "user".to_string();
         let vouchee = "vouchee".to_string();

--- a/src/identity/punish/storage.rs
+++ b/src/identity/punish/storage.rs
@@ -115,3 +115,106 @@ impl PenaltyStorage for InMemoryPenaltyStorage {
             .collect())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[async_std::test]
+    async fn test_inmemory_penalty_storage() {
+        let storage = InMemoryPenaltyStorage::default();
+        let user = "user".to_string();
+        let vouchee = "vouchee".to_string();
+
+        let proof1 = ModeratorProof {
+            moderator: "mod".to_string(),
+            amount: 1,
+            proof_id: 1,
+            timestamp: 2,
+        };
+        storage
+            .set_moderator_penalty(user.clone(), proof1.clone())
+            .await
+            .unwrap();
+        let res = storage.moderator_penalty(&user).await.unwrap().unwrap();
+        assert_eq!(res.moderator, proof1.moderator);
+        assert_eq!(res.amount, proof1.amount);
+        assert_eq!(res.proof_id, proof1.proof_id);
+        assert_eq!(res.timestamp, proof1.timestamp);
+
+        let proof2 = ModeratorProof {
+            moderator: "mod2".to_string(),
+            amount: 3,
+            proof_id: 2,
+            timestamp: 4,
+        };
+        storage
+            .set_moderator_penalty(user.clone(), proof2.clone())
+            .await
+            .unwrap();
+        let res = storage.moderator_penalty(&user).await.unwrap().unwrap();
+        assert_eq!(res.moderator, proof2.moderator);
+        assert_eq!(res.amount, proof2.amount);
+        assert_eq!(res.proof_id, proof2.proof_id);
+        assert_eq!(res.timestamp, proof2.timestamp);
+
+        assert!(
+            storage
+                .moderator_penalty(&"none".to_string())
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        let penalty1 = SystemPenalty {
+            amount: 5,
+            timestamp: 6,
+        };
+        storage
+            .set_forgotten_penalty(user.clone(), vouchee.clone(), penalty1.clone())
+            .await
+            .unwrap();
+        let res = storage
+            .forgotten_penalty(&user, &vouchee)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(res.amount, penalty1.amount);
+        assert_eq!(res.timestamp, penalty1.timestamp);
+        assert!(
+            storage
+                .forgotten_users(&user)
+                .await
+                .unwrap()
+                .contains(&vouchee)
+        );
+
+        let penalty2 = SystemPenalty {
+            amount: 7,
+            timestamp: 8,
+        };
+        storage
+            .set_forgotten_penalty(user.clone(), vouchee.clone(), penalty2.clone())
+            .await
+            .unwrap();
+        let res = storage
+            .forgotten_penalty(&user, &vouchee)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(res.amount, penalty2.amount);
+        assert_eq!(res.timestamp, penalty2.timestamp);
+
+        storage
+            .remove_forgotten(user.clone(), &vouchee)
+            .await
+            .unwrap();
+        assert!(
+            storage
+                .forgotten_penalty(&user, &vouchee)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+}

--- a/src/identity/vouch/db.rs
+++ b/src/identity/vouch/db.rs
@@ -109,6 +109,21 @@ mod tests {
         let user_a = "user_a".to_string();
         let user_b = "user_b".to_string();
 
+        assert!(
+            storage
+                .vouchers_with_time(&user_b)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            storage
+                .vouchees_with_time(&user_a)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
         storage
             .vouch(user_a.clone(), user_b.clone(), 1)
             .await

--- a/src/identity/vouch/db.rs
+++ b/src/identity/vouch/db.rs
@@ -104,7 +104,7 @@ mod tests {
     use super::*;
 
     #[async_std::test]
-    async fn test_database_vouch_storage() {
+    async fn test_basic() {
         let storage = DatabaseVouchStorage::new("sqlite::memory:").await.unwrap();
         let user_a = "user_a".to_string();
         let user_b = "user_b".to_string();

--- a/src/identity/vouch/storage.rs
+++ b/src/identity/vouch/storage.rs
@@ -107,7 +107,7 @@ mod tests {
     use super::*;
 
     #[async_std::test]
-    async fn test_inmemory_vouch_storage() {
+    async fn test_basic() {
         let storage = InMemoryVouchStorage::default();
         let user_a = "user_a".to_string();
         let user_b = "user_b".to_string();

--- a/src/identity/vouch/storage.rs
+++ b/src/identity/vouch/storage.rs
@@ -112,6 +112,21 @@ mod tests {
         let user_a = "user_a".to_string();
         let user_b = "user_b".to_string();
 
+        assert!(
+            storage
+                .vouchers_with_time(&user_b)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            storage
+                .vouchees_with_time(&user_a)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
         storage
             .vouch(user_a.clone(), user_b.clone(), 1)
             .await

--- a/src/verify/nonce/mod.rs
+++ b/src/verify/nonce/mod.rs
@@ -49,3 +49,29 @@ impl NonceManager for InMemoryNonceManager {
             .ok_or(Error::NonceOverflowError)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::verify::random_keypair;
+
+    #[async_std::test]
+    async fn test_basic() {
+        let (_priv, user) = random_keypair();
+        let manager = InMemoryNonceManager::default();
+
+        // next nonce should be 1
+        assert_eq!(manager.next_nonce(&user).await.unwrap(), 1);
+        // next nonce should still be 1 until we use it
+        assert_eq!(manager.next_nonce(&user).await.unwrap(), 1);
+
+        manager.use_nonce(&user, 1).await.unwrap();
+        // next nonce should now be 2
+        assert_eq!(manager.next_nonce(&user).await.unwrap(), 2);
+
+        // using same nonce again should fail
+        assert!(manager.use_nonce(&user, 1).await.is_err());
+        // next nonce does not increment if use_nonce fails
+        assert_eq!(manager.next_nonce(&user).await.unwrap(), 2);
+    }
+}


### PR DESCRIPTION
## Summary
- add async tests to `InMemoryProofStorage`
- add async tests to `InMemoryPenaltyStorage`
- add async tests to `InMemoryVouchStorage`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6869c139abe48328ac54010b86c918ab