### PR TITLE
Add database migrations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ ethers-core = "2"
 ethers-signers = "2"
 hex = "0.4"
 async-trait = "0.1"
-sqlx = { version = "0.7", default-features = false, features = ["runtime-async-std-native-tls", "macros", "mysql", "sqlite", "any"] }
+sqlx = { version = "0.7", default-features = false, features = ["runtime-async-std-native-tls", "macros", "mysql", "sqlite", "any", "migrate"] }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/migrations/20240101000000_initial.sql
+++ b/migrations/20240101000000_initial.sql
@@ -1,0 +1,51 @@
+CREATE TABLE IF NOT EXISTS vouches (
+    voucher TEXT NOT NULL,
+    vouchee TEXT NOT NULL,
+    timestamp INTEGER NOT NULL,
+    PRIMARY KEY (voucher, vouchee)
+);
+CREATE INDEX IF NOT EXISTS voucher_idx ON vouches(voucher);
+CREATE INDEX IF NOT EXISTS vouchee_idx ON vouches(vouchee);
+
+CREATE TABLE IF NOT EXISTS proofs (
+    user TEXT PRIMARY KEY,
+    moderator TEXT NOT NULL,
+    amount INTEGER NOT NULL,
+    proof_id INTEGER NOT NULL,
+    timestamp INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS genesis (
+    user TEXT PRIMARY KEY,
+    balance INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS moderator_penalties (
+    user TEXT PRIMARY KEY,
+    moderator TEXT NOT NULL,
+    amount INTEGER NOT NULL,
+    proof_id INTEGER NOT NULL,
+    timestamp INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS forget_penalties (
+    user TEXT NOT NULL,
+    forgotten TEXT NOT NULL,
+    amount INTEGER NOT NULL,
+    timestamp INTEGER NOT NULL,
+    PRIMARY KEY (user, forgotten)
+);
+CREATE INDEX IF NOT EXISTS forget_penalties_idx ON forget_penalties(user);
+
+CREATE TABLE IF NOT EXISTS admins (
+    user TEXT PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS moderators (
+    user TEXT PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS nonces (
+    user TEXT PRIMARY KEY,
+    used_nonce INTEGER NOT NULL
+);

--- a/src/admins/db.rs
+++ b/src/admins/db.rs
@@ -6,6 +6,7 @@ use sqlx::any::AnyPoolOptions;
 
 use crate::admins::{AdminStorage, error::Error};
 use crate::identity::UserAddress;
+use crate::migration;
 
 pub struct DatabaseAdminStorage {
     pool: AnyPool,
@@ -22,12 +23,7 @@ impl DatabaseAdminStorage {
             .max_connections(1)
             .connect(url)
             .await?;
-        sqlx::query("CREATE TABLE IF NOT EXISTS admins (user TEXT PRIMARY KEY)")
-            .execute(&pool)
-            .await?;
-        sqlx::query("CREATE TABLE IF NOT EXISTS moderators (user TEXT PRIMARY KEY)")
-            .execute(&pool)
-            .await?;
+        migration::run_migrations(&pool).await?;
         for admin in admins {
             sqlx::query("INSERT OR IGNORE INTO admins (user) VALUES (?)")
                 .bind(admin)

--- a/src/identity/proof/db.rs
+++ b/src/identity/proof/db.rs
@@ -6,6 +6,7 @@ use sqlx::{Acquire, AnyPool, Row, any::AnyPoolOptions};
 use crate::identity::{
     IdtAmount, ModeratorProof, ProofId, UserAddress, error::Error, proof::storage::ProofStorage,
 };
+use crate::migration;
 
 pub struct DatabaseProofStorage {
     pool: AnyPool,
@@ -18,16 +19,7 @@ impl DatabaseProofStorage {
             .max_connections(1)
             .connect(url)
             .await?;
-        sqlx::query(
-            "CREATE TABLE IF NOT EXISTS proofs (user TEXT PRIMARY KEY, moderator TEXT NOT NULL, amount INTEGER NOT NULL, proof_id INTEGER NOT NULL, timestamp INTEGER NOT NULL)"
-        )
-        .execute(&pool)
-        .await?;
-        sqlx::query(
-            "CREATE TABLE IF NOT EXISTS genesis (user TEXT PRIMARY KEY, balance INTEGER NOT NULL)",
-        )
-        .execute(&pool)
-        .await?;
+        migration::run_migrations(&pool).await?;
         Ok(Self { pool })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod admins;
 pub mod identity;
+pub mod migration;
 pub mod routes;
 pub mod verify;

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -1,0 +1,11 @@
+use sqlx::{AnyPool, Error, migrate::Migrator};
+
+// embed migrations from the crate root `migrations` directory
+pub static MIGRATOR: Migrator = sqlx::migrate!("./migrations");
+
+pub async fn run_migrations(pool: &AnyPool) -> Result<(), Error> {
+    MIGRATOR
+        .run(pool)
+        .await
+        .map_err(|e| Error::Migrate(Box::new(e)))
+}

--- a/src/verify/nonce/db.rs
+++ b/src/verify/nonce/db.rs
@@ -3,6 +3,7 @@ use sqlx::any::AnyPoolOptions;
 use sqlx::{Acquire, AnyPool, Row};
 
 use crate::identity::UserAddress;
+use crate::migration;
 use crate::verify::nonce::error::Error;
 use crate::verify::nonce::{Nonce, NonceManager};
 
@@ -17,11 +18,7 @@ impl DatabaseNonceManager {
             .max_connections(1)
             .connect(url)
             .await?;
-        sqlx::query(
-            "CREATE TABLE IF NOT EXISTS nonces (user TEXT PRIMARY KEY, used_nonce INTEGER NOT NULL)"
-        )
-        .execute(&pool)
-        .await?;
+        migration::run_migrations(&pool).await?;
         Ok(Self { pool })
     }
 }


### PR DESCRIPTION
## Summary
- embed SQLx migrations
- use migrations during persistent backend initialization

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6869c4f8b4a88328853264a74796579b