### PR TITLE
Add server signature verification for vouch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,7 @@ async fn main() {
         identity_service,
         admin_storage: storage.admin_storage,
         nonce_manager: storage.nonce_manager,
+        external_servers: config.external_servers,
     };
 
     log::info!("Starting identity server");

--- a/src/routes/admins/add_admin.rs
+++ b/src/routes/admins/add_admin.rs
@@ -85,6 +85,7 @@ mod tests {
 
     use crate::{
         admins::{AdminStorage, InMemoryAdminStorage},
+        config::ExternalServersSection,
         identity::IdentityService,
         verify::{admin::admin_sign, nonce::InMemoryNonceManager, random_keypair},
     };
@@ -102,6 +103,7 @@ mod tests {
             identity_service: IdentityService::default(),
             admin_storage: admin_storage.clone(),
             nonce_manager: Arc::new(InMemoryNonceManager::default()),
+            external_servers: ExternalServersSection::default(),
         };
 
         let new_admin = "new_admin_user".to_string();
@@ -149,6 +151,7 @@ mod tests {
             identity_service: IdentityService::default(),
             admin_storage,
             nonce_manager: Arc::new(InMemoryNonceManager::default()),
+            external_servers: ExternalServersSection::default(),
         };
 
         let new_admin = "new_admin_user".to_string();

--- a/src/routes/admins/add_moderator.rs
+++ b/src/routes/admins/add_moderator.rs
@@ -85,6 +85,7 @@ mod tests {
 
     use crate::{
         admins::{AdminStorage, InMemoryAdminStorage},
+        config::ExternalServersSection,
         identity::IdentityService,
         verify::{moderator::moderator_sign, nonce::InMemoryNonceManager, random_keypair},
     };
@@ -102,6 +103,7 @@ mod tests {
             identity_service: IdentityService::default(),
             admin_storage: admin_storage.clone(),
             nonce_manager: Arc::new(InMemoryNonceManager::default()),
+            external_servers: ExternalServersSection::default(),
         };
 
         let new_moderator = "new_moderator_user".to_string();
@@ -149,6 +151,7 @@ mod tests {
             identity_service: IdentityService::default(),
             admin_storage,
             nonce_manager: Arc::new(InMemoryNonceManager::default()),
+            external_servers: ExternalServersSection::default(),
         };
 
         let new_moderator = "new_moderator_user".to_string();

--- a/src/routes/admins/is_admin.rs
+++ b/src/routes/admins/is_admin.rs
@@ -26,6 +26,7 @@ mod tests {
 
     use crate::{
         admins::InMemoryAdminStorage, identity::IdentityService,
+        config::ExternalServersSection,
         verify::nonce::InMemoryNonceManager,
     };
 
@@ -42,6 +43,7 @@ mod tests {
             identity_service: IdentityService::default(),
             admin_storage,
             nonce_manager: Arc::new(InMemoryNonceManager::default()),
+            external_servers: ExternalServersSection::default(),
         };
 
         // test for admin user

--- a/src/routes/admins/is_moderator.rs
+++ b/src/routes/admins/is_moderator.rs
@@ -30,6 +30,7 @@ mod tests {
 
     use crate::{
         admins::InMemoryAdminStorage, identity::IdentityService,
+        config::ExternalServersSection,
         verify::nonce::InMemoryNonceManager,
     };
 
@@ -46,6 +47,7 @@ mod tests {
             identity_service: IdentityService::default(),
             admin_storage,
             nonce_manager: Arc::new(InMemoryNonceManager::default()),
+            external_servers: ExternalServersSection::default(),
         };
 
         // test for moderator user

--- a/src/routes/admins/remove_admin.rs
+++ b/src/routes/admins/remove_admin.rs
@@ -85,6 +85,7 @@ mod tests {
 
     use crate::{
         admins::{AdminStorage, InMemoryAdminStorage},
+        config::ExternalServersSection,
         identity::IdentityService,
         verify::{admin::admin_sign, nonce::InMemoryNonceManager, random_keypair},
     };
@@ -103,6 +104,7 @@ mod tests {
             identity_service: IdentityService::default(),
             admin_storage: admin_storage.clone(),
             nonce_manager: Arc::new(InMemoryNonceManager::default()),
+            external_servers: ExternalServersSection::default(),
         };
 
         let req_url = format!("/remove_admin/{other_admin}");
@@ -149,6 +151,7 @@ mod tests {
             identity_service: IdentityService::default(),
             admin_storage,
             nonce_manager: Arc::new(InMemoryNonceManager::default()),
+            external_servers: ExternalServersSection::default(),
         };
 
         let user = "new_admin_user".to_string();

--- a/src/routes/admins/remove_moderator.rs
+++ b/src/routes/admins/remove_moderator.rs
@@ -85,6 +85,7 @@ mod tests {
 
     use crate::{
         admins::{AdminStorage, InMemoryAdminStorage},
+        config::ExternalServersSection,
         identity::IdentityService,
         verify::{moderator::moderator_sign, nonce::InMemoryNonceManager, random_keypair},
     };
@@ -104,6 +105,7 @@ mod tests {
             identity_service: IdentityService::default(),
             admin_storage: admin_storage.clone(),
             nonce_manager: Arc::new(InMemoryNonceManager::default()),
+            external_servers: ExternalServersSection::default(),
         };
 
         let req_url = format!("/remove_moderator/{moderator}");
@@ -152,6 +154,7 @@ mod tests {
             identity_service: IdentityService::default(),
             admin_storage,
             nonce_manager: Arc::new(InMemoryNonceManager::default()),
+            external_servers: ExternalServersSection::default(),
         };
 
         let req_url = format!("/remove_moderator/{moderator}");

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::{
     admins::{AdminStorage, InMemoryAdminStorage},
+    config::ExternalServersSection,
     identity::IdentityService,
     verify::nonce::{InMemoryNonceManager, NonceManager},
 };
@@ -18,6 +19,7 @@ pub struct State {
     pub identity_service: IdentityService,
     pub admin_storage: Arc<dyn AdminStorage>,
     pub nonce_manager: Arc<dyn NonceManager>,
+    pub external_servers: ExternalServersSection,
 }
 
 impl Default for State {
@@ -26,6 +28,7 @@ impl Default for State {
             identity_service: IdentityService::default(),
             admin_storage: Arc::new(InMemoryAdminStorage::default()),
             nonce_manager: Arc::new(InMemoryNonceManager::default()),
+            external_servers: ExternalServersSection::default(),
         }
     }
 }

--- a/src/routes/proof.rs
+++ b/src/routes/proof.rs
@@ -108,6 +108,7 @@ mod tests {
             proof::MAX_IDT_BY_PROOF,
             tests::{PROOF_ID, USER_A},
         },
+        config::ExternalServersSection,
         verify::{nonce::InMemoryNonceManager, proof::proof_sign, random_keypair},
     };
     use serde_json::Value;
@@ -122,6 +123,7 @@ mod tests {
             identity_service: IdentityService::default(),
             admin_storage,
             nonce_manager: Arc::new(InMemoryNonceManager::default()),
+            external_servers: ExternalServersSection::default(),
         };
         let user_id = USER_A;
         let amount = 5000;
@@ -174,6 +176,7 @@ mod tests {
             identity_service: IdentityService::default(),
             admin_storage,
             nonce_manager: Arc::new(InMemoryNonceManager::default()),
+            external_servers: ExternalServersSection::default(),
         };
         let user_id = USER_A;
         let amount = MAX_IDT_BY_PROOF + 1;
@@ -262,6 +265,7 @@ mod tests {
             identity_service: IdentityService::default(),
             admin_storage,
             nonce_manager: Arc::new(InMemoryNonceManager::default()),
+            external_servers: ExternalServersSection::default(),
         };
 
         let target_user = "test_user".to_string();

--- a/src/routes/punish.rs
+++ b/src/routes/punish.rs
@@ -97,6 +97,7 @@ mod tests {
             proof::prove,
             tests::{MODERATOR, PROOF_ID, USER_A},
         },
+        config::ExternalServersSection,
         verify::{nonce::InMemoryNonceManager, punish::punish_sign, random_keypair},
     };
     use serde_json::Value;
@@ -111,6 +112,7 @@ mod tests {
             identity_service: IdentityService::default(),
             admin_storage,
             nonce_manager: Arc::new(InMemoryNonceManager::default()),
+            external_servers: ExternalServersSection::default(),
         };
         let user_id = USER_A;
         let amount = 5000;
@@ -206,6 +208,7 @@ mod tests {
             identity_service: IdentityService::default(),
             admin_storage,
             nonce_manager: Arc::new(InMemoryNonceManager::default()),
+            external_servers: ExternalServersSection::default(),
         };
 
         let target_user = "test_user".to_string();


### PR DESCRIPTION
## Summary
- support optional server signature in `vouch` route
- store allowed external servers in server state
- verify server signature and check it against config
- expose `vouch_server_sign` and `vouch_server_verify`
- update tests for new behaviour

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686bca42b10c8328b8c81d8a42962c39