### PR TITLE
Add external server config support

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -2,5 +2,9 @@
   "admins": {
     "admins": [],
     "moderators": []
+  },
+  "external_servers": {
+    "allow_all": false,
+    "servers": []
   }
 }


### PR DESCRIPTION
## Summary
- add a new `ExternalServersSection` to hold server allow list
- include optional whitelist in config template
- verify new configuration in unit tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686e52d8d6a4832895835c4b4b033053