### PR TITLE
Support optional voucher server

### DIFF
--- a/src/routes/forget.rs
+++ b/src/routes/forget.rs
@@ -13,6 +13,7 @@ use crate::{
 #[derive(Deserialize, Serialize, Clone)]
 struct FromField {
     user: UserAddress,
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     server: Option<UserAddress>,
 }

--- a/src/routes/vouch.rs
+++ b/src/routes/vouch.rs
@@ -13,6 +13,7 @@ use crate::{
 #[derive(Deserialize, Serialize, Clone)]
 struct FromField {
     user: UserAddress,
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     server: Option<UserAddress>,
 }


### PR DESCRIPTION
## Summary
- add optional `server` field inside `from` for forget and vouch routes
- include server data in responses when provided
- update forget and vouch tests for new `from` structure

## Testing
- `cargo test` *(fails: linker `cc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884d384e5c883288629d1f02babbf7b