### PR TITLE
Handle external server vouches separately

### DIFF
--- a/src/identity/decay.rs
+++ b/src/identity/decay.rs
@@ -192,7 +192,13 @@ mod tests {
             0
         );
         service
-            .vouch_with_timestamp(user_b.to_string(), USER_A.to_string(), ts)
+            .vouch_with_timestamp(
+                User::LocalUser {
+                    user: user_b.to_string(),
+                },
+                USER_A.to_string(),
+                ts,
+            )
             .await
             .unwrap();
         assert_eq!(
@@ -202,7 +208,13 @@ mod tests {
             0
         );
         service
-            .vouch_with_timestamp(user_b.to_string(), USER_A.to_string(), ts - 86400)
+            .vouch_with_timestamp(
+                User::LocalUser {
+                    user: user_b.to_string(),
+                },
+                USER_A.to_string(),
+                ts - 86400,
+            )
             .await
             .unwrap();
         assert_eq!(
@@ -212,7 +224,13 @@ mod tests {
             1
         );
         service
-            .vouch_with_timestamp(user_b.to_string(), USER_A.to_string(), ts - 100000)
+            .vouch_with_timestamp(
+                User::LocalUser {
+                    user: user_b.to_string(),
+                },
+                USER_A.to_string(),
+                ts - 100000,
+            )
             .await
             .unwrap();
         assert_eq!(
@@ -222,7 +240,13 @@ mod tests {
             1
         );
         service
-            .vouch_with_timestamp(user_b.to_string(), USER_A.to_string(), ts - 86400 * 2)
+            .vouch_with_timestamp(
+                User::LocalUser {
+                    user: user_b.to_string(),
+                },
+                USER_A.to_string(),
+                ts - 86400 * 2,
+            )
             .await
             .unwrap();
         assert_eq!(

--- a/src/identity/idt.rs
+++ b/src/identity/idt.rs
@@ -458,7 +458,13 @@ mod tests {
         assert_eq!(balance(&service, &USER_A.to_string()).await.unwrap(), 100);
 
         service
-            .vouch_with_timestamp(user_b.to_string(), USER_A.to_string(), ts - 86400)
+            .vouch_with_timestamp(
+                User::LocalUser {
+                    user: user_b.to_string(),
+                },
+                USER_A.to_string(),
+                ts - 86400,
+            )
             .await
             .unwrap();
         // vouch balance also decays at 1 IDT per day rate

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -20,6 +20,34 @@ pub type UserAddress = String;
 pub type ProofId = u64;
 pub type IdtAmount = u64;
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum User {
+    LocalUser {
+        user: UserAddress,
+    },
+    ExternalUser {
+        user: UserAddress,
+        server: UserAddress,
+    },
+}
+
+impl User {
+    pub fn address(&self) -> &UserAddress {
+        match self {
+            User::LocalUser { user } => user,
+            User::ExternalUser { user, .. } => user,
+        }
+    }
+
+    pub fn server(&self) -> Option<&UserAddress> {
+        match self {
+            User::LocalUser { .. } => None,
+            User::ExternalUser { server, .. } => Some(server),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct ModeratorProof {
     pub moderator: UserAddress,


### PR DESCRIPTION
## Summary
- store external server vouches separately in storage
- add server parameter to vouch and forget handlers
- update database and in-memory vouch storage
- update routes to pass external server info
- refactor vouch/forget requests to use `User` enum

## Testing
- `cargo fmt --all`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_6884fdbad5a48328a00aef5088781c45