### PR TITLE
Add external voucher module

### DIFF
--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -4,6 +4,7 @@ use crate::identity::{
     proof::storage::{InMemoryProofStorage, ProofStorage},
     punish::storage::{InMemoryPenaltyStorage, PenaltyStorage},
     vouch::storage::{InMemoryVouchStorage, VouchStorage},
+    vouch_external::storage::{ExternalVouchStorage, InMemoryExternalVouchStorage},
 };
 
 mod decay;
@@ -15,6 +16,7 @@ pub mod proof;
 pub mod punish;
 mod tree_walk;
 pub mod vouch;
+pub mod vouch_external;
 
 pub type UserAddress = String;
 pub type ProofId = u64;
@@ -38,6 +40,7 @@ pub struct SystemPenalty {
 #[derive(Clone)]
 pub struct IdentityService {
     pub vouches: Arc<dyn VouchStorage>,
+    pub external_vouches: Arc<dyn ExternalVouchStorage>,
     pub proofs: Arc<dyn ProofStorage>,
     pub penalties: Arc<dyn PenaltyStorage>,
 }
@@ -46,6 +49,7 @@ impl Default for IdentityService {
     fn default() -> Self {
         Self {
             vouches: Arc::new(InMemoryVouchStorage::default()),
+            external_vouches: Arc::new(InMemoryExternalVouchStorage::default()),
             proofs: Arc::new(InMemoryProofStorage::default()),
             penalties: Arc::new(InMemoryPenaltyStorage::default()),
         }

--- a/src/identity/vouch_external/db.rs
+++ b/src/identity/vouch_external/db.rs
@@ -1,0 +1,97 @@
+use async_trait::async_trait;
+use sqlx::{AnyPool, Row, any::AnyPoolOptions};
+
+use super::storage::ExternalVouchStorage;
+use crate::identity::{UserAddress, error::Error};
+use std::collections::HashMap;
+
+pub struct DatabaseExternalVouchStorage {
+    pool: AnyPool,
+}
+
+impl DatabaseExternalVouchStorage {
+    pub async fn new(url: &str) -> Result<Self, Error> {
+        sqlx::any::install_default_drivers();
+        let pool = AnyPoolOptions::new()
+            .max_connections(1)
+            .connect(url)
+            .await?;
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS external_vouches (server TEXT NOT NULL, voucher TEXT NOT NULL, vouchee TEXT NOT NULL, timestamp INTEGER NOT NULL, PRIMARY KEY(server, voucher, vouchee))",
+        )
+        .execute(&pool)
+        .await?;
+        sqlx::query("CREATE INDEX IF NOT EXISTS external_vouch_idx ON external_vouches(voucher)")
+            .execute(&pool)
+            .await?;
+        sqlx::query("CREATE INDEX IF NOT EXISTS external_vouchee_idx ON external_vouches(vouchee)")
+            .execute(&pool)
+            .await?;
+        Ok(Self { pool })
+    }
+}
+
+#[async_trait]
+impl ExternalVouchStorage for DatabaseExternalVouchStorage {
+    async fn vouch(
+        &self,
+        server: UserAddress,
+        from: UserAddress,
+        to: UserAddress,
+        timestamp: u64,
+    ) -> Result<(), Error> {
+        sqlx::query(
+            "REPLACE INTO external_vouches (server, voucher, vouchee, timestamp) VALUES (?, ?, ?, ?)",
+        )
+        .bind(&server)
+        .bind(&from)
+        .bind(&to)
+        .bind(timestamp as i64)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn vouchers_by_server_with_time(
+        &self,
+        user: &UserAddress,
+    ) -> Result<HashMap<UserAddress, HashMap<UserAddress, u64>>, Error> {
+        let rows = sqlx::query(
+            "SELECT server, voucher, timestamp FROM external_vouches WHERE vouchee = ?",
+        )
+        .bind(user)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut map: HashMap<UserAddress, HashMap<UserAddress, u64>> = HashMap::new();
+        for r in rows {
+            let server: String = r.get(0);
+            let voucher: String = r.get(1);
+            let ts: i64 = r.get(2);
+            map.entry(server)
+                .or_default()
+                .insert(voucher, ts as u64);
+        }
+        Ok(map)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[async_std::test]
+    async fn test_basic() {
+        let storage = DatabaseExternalVouchStorage::new("sqlite::memory:")
+            .await
+            .unwrap();
+        storage
+            .vouch("server".into(), "from".into(), "to".into(), 1)
+            .await
+            .unwrap();
+        let map = storage
+            .vouchers_by_server_with_time(&"to".to_string())
+            .await
+            .unwrap();
+        assert_eq!(map.get("server").unwrap().get("from").copied().unwrap(), 1);
+    }
+}

--- a/src/identity/vouch_external/db.rs
+++ b/src/identity/vouch_external/db.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use sqlx::{AnyPool, Row, any::AnyPoolOptions};
 
 use super::storage::ExternalVouchStorage;
-use crate::identity::{UserAddress, error::Error};
+use crate::identity::{UserAddress, error::Error, vouch_external::storage::ServerWithVoucher};
 use std::collections::HashMap;
 
 pub struct DatabaseExternalVouchStorage {
@@ -21,9 +21,11 @@ impl DatabaseExternalVouchStorage {
         )
         .execute(&pool)
         .await?;
-        sqlx::query("CREATE INDEX IF NOT EXISTS external_vouch_idx ON external_vouches(voucher)")
-            .execute(&pool)
-            .await?;
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS external_voucher_idx ON external_vouches(server, voucher)",
+        )
+        .execute(&pool)
+        .await?;
         sqlx::query("CREATE INDEX IF NOT EXISTS external_vouchee_idx ON external_vouches(vouchee)")
             .execute(&pool)
             .await?;
@@ -52,10 +54,7 @@ impl ExternalVouchStorage for DatabaseExternalVouchStorage {
         Ok(())
     }
 
-    async fn vouchers_by_server_with_time(
-        &self,
-        user: &UserAddress,
-    ) -> Result<HashMap<UserAddress, HashMap<UserAddress, u64>>, Error> {
+    async fn vouchers_with_time(&self, user: &UserAddress) -> Result<ServerWithVoucher, Error> {
         let rows = sqlx::query(
             "SELECT server, voucher, timestamp FROM external_vouches WHERE vouchee = ?",
         )
@@ -67,11 +66,26 @@ impl ExternalVouchStorage for DatabaseExternalVouchStorage {
             let server: String = r.get(0);
             let voucher: String = r.get(1);
             let ts: i64 = r.get(2);
-            map.entry(server)
-                .or_default()
-                .insert(voucher, ts as u64);
+            map.entry(server).or_default().insert(voucher, ts as u64);
         }
         Ok(map)
+    }
+
+    async fn remove_vouch(
+        &self,
+        server: UserAddress,
+        from: UserAddress,
+        to: UserAddress,
+    ) -> Result<(), Error> {
+        sqlx::query(
+            "DELETE FROM external_vouches WHERE server = ? AND voucher = ? AND vouchee = ?",
+        )
+        .bind(&server)
+        .bind(&from)
+        .bind(&to)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
     }
 }
 
@@ -88,10 +102,28 @@ mod tests {
             .vouch("server".into(), "from".into(), "to".into(), 1)
             .await
             .unwrap();
-        let map = storage
-            .vouchers_by_server_with_time(&"to".to_string())
+        let map = storage.vouchers_with_time(&"to".to_string()).await.unwrap();
+        assert_eq!(map.get("server").unwrap().get("from").copied().unwrap(), 1);
+    }
+
+    #[async_std::test]
+    async fn test_remove_vouch() {
+        let storage = DatabaseExternalVouchStorage::new("sqlite::memory:")
             .await
             .unwrap();
+        storage
+            .vouch("server".into(), "from".into(), "to".into(), 1)
+            .await
+            .unwrap();
+        let map = storage.vouchers_with_time(&"to".into()).await.unwrap();
         assert_eq!(map.get("server").unwrap().get("from").copied().unwrap(), 1);
+
+        storage
+            .remove_vouch("server".into(), "from".into(), "to".into())
+            .await
+            .unwrap();
+        // verify it no longer exists
+        let map = storage.vouchers_with_time(&"to".into()).await.unwrap();
+        assert!(map.get("server").is_none());
     }
 }

--- a/src/identity/vouch_external/mod.rs
+++ b/src/identity/vouch_external/mod.rs
@@ -1,0 +1,89 @@
+use crate::identity::{IdentityService, UserAddress, error::Error, next_timestamp};
+use std::collections::HashMap;
+
+pub mod db;
+pub mod storage;
+
+impl IdentityService {
+    pub async fn vouch_external_with_timestamp(
+        &self,
+        server: UserAddress,
+        from: UserAddress,
+        to: UserAddress,
+        timestamp: u64,
+    ) -> Result<(), Error> {
+        self.external_vouches
+            .vouch(server, from, to, timestamp)
+            .await
+    }
+
+    pub async fn vouches_by_server_with_time(
+        &self,
+        user: &UserAddress,
+    ) -> Result<HashMap<UserAddress, HashMap<UserAddress, u64>>, Error> {
+        self.external_vouches
+            .vouchers_by_server_with_time(user)
+            .await
+    }
+}
+
+pub async fn vouch_external(
+    service: &IdentityService,
+    server: UserAddress,
+    from: UserAddress,
+    to: UserAddress,
+) -> Result<(), Error> {
+    service
+        .vouch_external_with_timestamp(server, from, to, next_timestamp())
+        .await
+}
+
+pub async fn vouches_by_server_with_time(
+    service: &IdentityService,
+    user: &UserAddress,
+) -> Result<HashMap<UserAddress, HashMap<UserAddress, u64>>, Error> {
+    service.vouches_by_server_with_time(user).await
+}
+
+pub async fn vouches_by_server(
+    service: &IdentityService,
+    user: &UserAddress,
+) -> Result<HashMap<UserAddress, Vec<UserAddress>>, Error> {
+    Ok(vouches_by_server_with_time(service, user)
+        .await?
+        .into_iter()
+        .map(|(srv, v)| (srv, v.into_keys().collect()))
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identity::tests::USER_A;
+
+    #[async_std::test]
+    async fn test_basic() {
+        let service = IdentityService::default();
+        let user_b = "userB";
+        let server = "server";
+        assert!(
+            vouches_by_server(&service, &user_b.to_string())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        vouch_external(
+            &service,
+            server.to_string(),
+            USER_A.to_string(),
+            user_b.to_string(),
+        )
+        .await
+        .unwrap();
+        let map = vouches_by_server(&service, &user_b.to_string())
+            .await
+            .unwrap();
+        assert_eq!(map.len(), 1);
+        assert!(map.get(server).unwrap().contains(&USER_A.to_string()));
+    }
+}

--- a/src/identity/vouch_external/storage.rs
+++ b/src/identity/vouch_external/storage.rs
@@ -5,6 +5,13 @@ use async_trait::async_trait;
 
 use crate::identity::{UserAddress, error::Error};
 
+// key - voucher
+pub type VoucherWithTime = HashMap<UserAddress, u64>;
+// key - server
+pub type ServerWithVoucher = HashMap<UserAddress, VoucherWithTime>;
+// key - vouchee
+pub type VoucheeWithServer = HashMap<UserAddress, ServerWithVoucher>;
+
 #[async_trait]
 pub trait ExternalVouchStorage: Send + Sync {
     async fn vouch(
@@ -15,20 +22,19 @@ pub trait ExternalVouchStorage: Send + Sync {
         timestamp: u64,
     ) -> Result<(), Error>;
 
-    async fn vouchers_by_server_with_time(
-        &self,
-        user: &UserAddress,
-    ) -> Result<HashMap<UserAddress, HashMap<UserAddress, u64>>, Error>;
-}
+    async fn vouchers_with_time(&self, user: &UserAddress) -> Result<ServerWithVoucher, Error>;
 
-#[derive(Default)]
-struct ExternalVouchData {
-    vouchers: HashMap<UserAddress, HashMap<UserAddress, HashMap<UserAddress, u64>>>,
+    async fn remove_vouch(
+        &self,
+        server: UserAddress,
+        from: UserAddress,
+        to: UserAddress,
+    ) -> Result<(), Error>;
 }
 
 #[derive(Default)]
 pub struct InMemoryExternalVouchStorage {
-    data: RwLock<ExternalVouchData>,
+    data: RwLock<VoucheeWithServer>,
 }
 
 #[async_trait]
@@ -41,8 +47,7 @@ impl ExternalVouchStorage for InMemoryExternalVouchStorage {
         timestamp: u64,
     ) -> Result<(), Error> {
         let mut lock = self.data.write().await;
-        lock.vouchers
-            .entry(to)
+        lock.entry(to)
             .or_default()
             .entry(server)
             .or_default()
@@ -50,18 +55,33 @@ impl ExternalVouchStorage for InMemoryExternalVouchStorage {
         Ok(())
     }
 
-    async fn vouchers_by_server_with_time(
-        &self,
-        user: &UserAddress,
-    ) -> Result<HashMap<UserAddress, HashMap<UserAddress, u64>>, Error> {
+    async fn vouchers_with_time(&self, user: &UserAddress) -> Result<ServerWithVoucher, Error> {
         Ok(self
             .data
             .read()
             .await
-            .vouchers
             .get(user)
             .cloned()
             .unwrap_or_default())
+    }
+
+    async fn remove_vouch(
+        &self,
+        server: UserAddress,
+        from: UserAddress,
+        to: UserAddress,
+    ) -> Result<(), Error> {
+        let mut lock = self.data.write().await;
+        let server_map = match lock.get_mut(&to) {
+            Some(map) => map,
+            None => return Ok(()),
+        };
+        let vouchers = match server_map.get_mut(&server) {
+            Some(vouchers) => vouchers,
+            None => return Ok(()),
+        };
+        vouchers.remove(&from);
+        Ok(())
     }
 }
 
@@ -76,10 +96,27 @@ mod tests {
             .vouch("server".into(), "from".into(), "to".into(), 1)
             .await
             .unwrap();
-        let map = storage
-            .vouchers_by_server_with_time(&"to".to_string())
+        let map = storage.vouchers_with_time(&"to".to_string()).await.unwrap();
+        assert_eq!(map.get("server").unwrap().get("from").copied().unwrap(), 1);
+    }
+
+    #[async_std::test]
+    async fn test_remove_vouch() {
+        let storage = InMemoryExternalVouchStorage::default();
+        storage
+            .vouch("server".into(), "from".into(), "to".into(), 1)
             .await
             .unwrap();
+
+        let map = storage.vouchers_with_time(&"to".into()).await.unwrap();
         assert_eq!(map.get("server").unwrap().get("from").copied().unwrap(), 1);
+
+        storage
+            .remove_vouch("server".into(), "from".into(), "to".into())
+            .await
+            .unwrap();
+        // verify it no longer exists
+        let map = storage.vouchers_with_time(&"to".into()).await.unwrap();
+        assert!(map.get("server").unwrap().get("from").is_none());
     }
 }

--- a/src/identity/vouch_external/storage.rs
+++ b/src/identity/vouch_external/storage.rs
@@ -1,0 +1,85 @@
+use std::collections::HashMap;
+
+use async_std::sync::RwLock;
+use async_trait::async_trait;
+
+use crate::identity::{UserAddress, error::Error};
+
+#[async_trait]
+pub trait ExternalVouchStorage: Send + Sync {
+    async fn vouch(
+        &self,
+        server: UserAddress,
+        from: UserAddress,
+        to: UserAddress,
+        timestamp: u64,
+    ) -> Result<(), Error>;
+
+    async fn vouchers_by_server_with_time(
+        &self,
+        user: &UserAddress,
+    ) -> Result<HashMap<UserAddress, HashMap<UserAddress, u64>>, Error>;
+}
+
+#[derive(Default)]
+struct ExternalVouchData {
+    vouchers: HashMap<UserAddress, HashMap<UserAddress, HashMap<UserAddress, u64>>>,
+}
+
+#[derive(Default)]
+pub struct InMemoryExternalVouchStorage {
+    data: RwLock<ExternalVouchData>,
+}
+
+#[async_trait]
+impl ExternalVouchStorage for InMemoryExternalVouchStorage {
+    async fn vouch(
+        &self,
+        server: UserAddress,
+        from: UserAddress,
+        to: UserAddress,
+        timestamp: u64,
+    ) -> Result<(), Error> {
+        let mut lock = self.data.write().await;
+        lock.vouchers
+            .entry(to)
+            .or_default()
+            .entry(server)
+            .or_default()
+            .insert(from, timestamp);
+        Ok(())
+    }
+
+    async fn vouchers_by_server_with_time(
+        &self,
+        user: &UserAddress,
+    ) -> Result<HashMap<UserAddress, HashMap<UserAddress, u64>>, Error> {
+        Ok(self
+            .data
+            .read()
+            .await
+            .vouchers
+            .get(user)
+            .cloned()
+            .unwrap_or_default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[async_std::test]
+    async fn test_basic() {
+        let storage = InMemoryExternalVouchStorage::default();
+        storage
+            .vouch("server".into(), "from".into(), "to".into(), 1)
+            .await
+            .unwrap();
+        let map = storage
+            .vouchers_by_server_with_time(&"to".to_string())
+            .await
+            .unwrap();
+        assert_eq!(map.get("server").unwrap().get("from").copied().unwrap(), 1);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,7 @@ async fn main() {
 
     let identity_service = IdentityService {
         vouches: storage.vouch_storage,
+        external_vouches: storage.external_vouch_storage,
         proofs: storage.proof_storage,
         penalties: storage.penalty_storage,
     };

--- a/src/routes/forget.rs
+++ b/src/routes/forget.rs
@@ -31,23 +31,22 @@ pub async fn route(mut req: Request<State>) -> tide::Result {
     let voucher = body.from;
     let voucher_user = voucher.user.clone();
 
+    if forget_verify(
+        body.signature,
+        &voucher_user,
+        body.nonce,
+        vouchee.clone(),
+        &*req.state().nonce_manager,
+    )
+    .await
+    .is_err()
     {
-        if forget_verify(
-            body.signature,
-            &voucher_user,
-            body.nonce,
-            vouchee.clone(),
-            &*req.state().nonce_manager,
-        )
-        .await
-        .is_err()
-        {
-            return Ok(Response::builder(400)
-                .body(json!({"error": "signature verification failed"}))
-                .content_type(mime::JSON)
-                .build());
-        }
+        return Ok(Response::builder(400)
+            .body(json!({"error": "signature verification failed"}))
+            .content_type(mime::JSON)
+            .build());
     }
+
     forget(
         &req.state().identity_service,
         voucher_user.clone(),

--- a/src/routes/proof.rs
+++ b/src/routes/proof.rs
@@ -37,24 +37,23 @@ pub async fn route(mut req: Request<State>) -> tide::Result {
             .content_type(mime::JSON)
             .build());
     }
+
+    if proof_verify(
+        body.signature,
+        &moderator,
+        body.nonce,
+        user.clone(),
+        amount,
+        proof_id,
+        &*req.state().nonce_manager,
+    )
+    .await
+    .is_err()
     {
-        if proof_verify(
-            body.signature,
-            &moderator,
-            body.nonce,
-            user.clone(),
-            amount,
-            proof_id,
-            &*req.state().nonce_manager,
-        )
-        .await
-        .is_err()
-        {
-            return Ok(Response::builder(400)
-                .body(json!({"error": "signature verification failed"}))
-                .content_type(mime::JSON)
-                .build());
-        }
+        return Ok(Response::builder(400)
+            .body(json!({"error": "signature verification failed"}))
+            .content_type(mime::JSON)
+            .build());
     }
 
     let prove_result = prove(

--- a/src/routes/punish.rs
+++ b/src/routes/punish.rs
@@ -38,24 +38,22 @@ pub async fn route(mut req: Request<State>) -> tide::Result {
             .build());
     }
 
+    if punish_verify(
+        body.signature,
+        &moderator,
+        body.nonce,
+        user.clone(),
+        amount,
+        proof_id,
+        &*req.state().nonce_manager,
+    )
+    .await
+    .is_err()
     {
-        if punish_verify(
-            body.signature,
-            &moderator,
-            body.nonce,
-            user.clone(),
-            amount,
-            proof_id,
-            &*req.state().nonce_manager,
-        )
-        .await
-        .is_err()
-        {
-            return Ok(Response::builder(400)
-                .body(json!({"error": "signature verification failed"}))
-                .content_type(mime::JSON)
-                .build());
-        }
+        return Ok(Response::builder(400)
+            .body(json!({"error": "signature verification failed"}))
+            .content_type(mime::JSON)
+            .build());
     }
 
     punish(

--- a/src/routes/vouch.rs
+++ b/src/routes/vouch.rs
@@ -30,6 +30,7 @@ pub async fn route(mut req: Request<State>) -> tide::Result {
     let body: VouchRequest = req.body_json().await?;
     let voucher = body.from;
     let voucher_user = voucher.user.clone();
+
     if vouch_verify(
         body.signature,
         &voucher_user,


### PR DESCRIPTION
## Summary
- move external vouch logic into `vouch_external` module
- store external voucher events separately in DB and in-memory implementations
- wire external vouchers into `IdentityService` and backend storage
- update vouch route to call `vouch_external`
- rework in-memory external vouch storage to use nested hashmaps
- add retrieval helper `vouches_by_server` with tests

## Testing
- `cargo check`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6885eea3d0ec8328815f70a09026a637