### PR TITLE
Handle forgetting external vouches

### DIFF
--- a/src/identity/vouch_external/mod.rs
+++ b/src/identity/vouch_external/mod.rs
@@ -40,6 +40,15 @@ impl IdentityService {
             .collect();
         Ok(vouchers)
     }
+
+    pub async fn remove_external_vouch(
+        &self,
+        server: UserAddress,
+        from: UserAddress,
+        to: UserAddress,
+    ) -> Result<(), Error> {
+        self.external_vouches.remove_vouch(server, from, to).await
+    }
 }
 
 pub async fn vouch_external(
@@ -51,6 +60,15 @@ pub async fn vouch_external(
     service
         .vouch_external_with_timestamp(server, from, to, next_timestamp())
         .await
+}
+
+pub async fn forget_external(
+    service: &IdentityService,
+    server: UserAddress,
+    from: UserAddress,
+    to: UserAddress,
+) -> Result<(), Error> {
+    service.remove_external_vouch(server, from, to).await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add `remove_external_vouch` and `forget_external` helpers
- make `/forget` route handle `server` field
- store external vouch in test and verify it gets removed

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68866dc5df608328a21070d62470af78